### PR TITLE
Add the Discord snowflake user ID to log when auto decaying roles

### DIFF
--- a/src/megabot-internals/intervals.js
+++ b/src/megabot-internals/intervals.js
@@ -58,7 +58,7 @@ module.exports = [
           const member = await global.bot.guilds.get(ids.guild).getRESTMember(x.wb_id)
           const roles = member.roles.filter(x => rewards.includes(x))
           dlog(4, {
-            message: `About to remove roles from ${member.username}#${member.discriminator} `\`\${member.id}`\`\. For reference later, they've accrued a total of ${x.properties.exp} EXP, and had ${roles.length} roles`
+            message: `About to remove roles from ${member.username}#${member.discriminator} \`\`${member.id}\`\`. For reference later, they've accrued a total of ${x.properties.exp} EXP, and had ${roles.length} roles`
           })
           roles.forEach(x => member.removeRole(x, 'Member considered stale'))
         } catch (e) { logger.warn(`Can't derole ${x.wb_id}: ${e.message}`) }

--- a/src/megabot-internals/intervals.js
+++ b/src/megabot-internals/intervals.js
@@ -58,7 +58,7 @@ module.exports = [
           const member = await global.bot.guilds.get(ids.guild).getRESTMember(x.wb_id)
           const roles = member.roles.filter(x => rewards.includes(x))
           dlog(4, {
-            message: `About to remove roles from ${member.username}#${member.discriminator}. For reference later, they've accrued a total of ${x.properties.exp} EXP, and had ${roles.length} roles`
+            message: `About to remove roles from ${member.username}#${member.discriminator} `\`\${member.id}`\`\. For reference later, they've accrued a total of ${x.properties.exp} EXP, and had ${roles.length} roles`
           })
           roles.forEach(x => member.removeRole(x, 'Member considered stale'))
         } catch (e) { logger.warn(`Can't derole ${x.wb_id}: ${e.message}`) }

--- a/src/megabot-internals/intervals.js
+++ b/src/megabot-internals/intervals.js
@@ -58,7 +58,7 @@ module.exports = [
           const member = await global.bot.guilds.get(ids.guild).getRESTMember(x.wb_id)
           const roles = member.roles.filter(x => rewards.includes(x))
           dlog(4, {
-            message: `About to remove roles from ${member.username}#${member.discriminator} \`\`${member.id}\`\`. For reference later, they've accrued a total of ${x.properties.exp} EXP, and had ${roles.length} roles`
+            message: `About to remove roles from ${member.username}#${member.discriminator} (\`${x.wb_id}\`). For reference later, they've accrued a total of ${x.properties.exp} EXP, and had ${roles.length} roles`
           })
           roles.forEach(x => member.removeRole(x, 'Member considered stale'))
         } catch (e) { logger.warn(`Can't derole ${x.wb_id}: ${e.message}`) }


### PR DESCRIPTION
# Please check the following boxes
> All boxes are required

- [X] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [X] I tested my code and I verified it's working to the best of my ability
- [X] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

Adds the userID of the account who's role is getting auto-removed to the bot logs.

**Why is this change needed?**


it hard to get find user esp when username change, this make it good to do that
