### PR TITLE
Remove Leaderboard interval to stop the error spam

### DIFF
--- a/src/megabot-internals/intervals.js
+++ b/src/megabot-internals/intervals.js
@@ -106,7 +106,7 @@ module.exports = [
     logger.debug('Refreshing top10')
     top10.regenerate()
   }, 3600000), // 1 hour
-  
+
   setInterval(() => {
     logger.debug('Refreshing feed')
     feed.refresh()

--- a/src/megabot-internals/intervals.js
+++ b/src/megabot-internals/intervals.js
@@ -106,7 +106,7 @@ module.exports = [
     logger.debug('Refreshing top10')
     top10.regenerate()
   }, 3600000), // 1 hour
-
+  
   setInterval(() => {
     logger.debug('Refreshing feed')
     feed.refresh()

--- a/src/megabot-internals/intervals.js
+++ b/src/megabot-internals/intervals.js
@@ -108,11 +108,6 @@ module.exports = [
   }, 3600000), // 1 hour
 
   setInterval(() => {
-    logger.debug('Refreshing leaderboard')
-    lb.update()
-  }, 3600000), // 1 hour
-
-  setInterval(() => {
     logger.debug('Refreshing feed')
     feed.refresh()
   }, MB_CONSTANTS.timeouts.feedScrape),


### PR DESCRIPTION
This is going to be temporary until the fix can be made.

# Please check the following boxes
> All boxes are required

- [x] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I tested my code and I verified it's working to the best of my ability
- [x] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

This is intended to stop the bot from refreshing the leaderboard.

**Why is this change needed?**

It was causing millions of errors to fill up Dougley's inbox.

**Does your pull request solve an open issue? If yes, please mention what one**

No.
