### PR TITLE
Help command

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,0 +1,10 @@
+module.exports = {
+  meta: {
+    level: 0
+  },
+  fn: (msg) => {
+    msg.channel.createMessage(`
+Looking to submit your own suggestion to our feedback site? Check out <#268812893087203338> for a detailed guide! If you’re having trouble, please reach out in any of the suggestion channels and a Custodian will help you out as soon as they’re able!
+    `)
+  }
+}

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -3,8 +3,6 @@ module.exports = {
     level: 0
   },
   fn: (msg) => {
-    msg.channel.createMessage(`
-Looking to submit your own suggestion to our feedback site? Check out <#268812893087203338> for a detailed guide! If you’re having trouble, please reach out in any of the suggestion channels and a Custodian will help you out as soon as they’re able!
-    `)
+    msg.channel.createMessage('Looking to submit your own suggestion to our feedback site? Check out <#268812893087203338> for a detailed guide! If you’re having trouble, please reach out in any of the suggestion channels and a Custodian will help you out as soon as they’re able!')
   }
 }


### PR DESCRIPTION
# Please check the following boxes
> All boxes are required

- [x] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I tested my code and I verified it's working to the best of my ability
- [x] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

> Adds a command that links directly to the bot instructions channel

**Why is this change needed?**

> Most users expect bots to have an help command, where instead MegaBot doesn't have one, so a custodian must go and use `!instructions` (which is a GearBoat tag).

**Does your pull request solve an open issue? If yes, please mention what one**
None.