### PR TITLE
Remove duplicate chatvotes

### DIFF
--- a/src/megabot-internals/controllers/inquirer.js
+++ b/src/megabot-internals/controllers/inquirer.js
@@ -12,10 +12,10 @@ module.exports = {
    */
   createChatvote: (msg, id, reportable = true) => {
     const existing = db.findSync('questions', {
-        zd_id: parseInt(id)
-     })
+      zd_id: parseInt(id)
+    })
     if (existing && (Date.now() - existing.meta.created) < 30000) return // If there's a document created less than 30 seconds ago with the same ID, we don't want to create a chatvote
-      
+    
     msg.addReaction(`${ids.emojis.upvote.name}:${ids.emojis.upvote.id}`)
     msg.addReaction(`${ids.emojis.downvote.name}:${ids.emojis.downvote.id}`)
     if (reportable && msg.author.id === global.bot.user.id) {

--- a/src/megabot-internals/controllers/inquirer.js
+++ b/src/megabot-internals/controllers/inquirer.js
@@ -14,7 +14,7 @@ module.exports = {
     const existing = db.findSync('questions', {
       zd_id: parseInt(id)
     })
-    if (existing && (Date.now() - existing.meta.created) < 30000) return // If there's a document created less than 30 seconds ago with the same ID, we don't want to create a chatvote
+    if (existing && (Date.now() - existing.meta.created) < 30000) reportable = false // If there's a document created less than 30 seconds ago with the same ID, we don't want to create a chatvote
 
     msg.addReaction(`${ids.emojis.upvote.name}:${ids.emojis.upvote.id}`)
     msg.addReaction(`${ids.emojis.downvote.name}:${ids.emojis.downvote.id}`)

--- a/src/megabot-internals/controllers/inquirer.js
+++ b/src/megabot-internals/controllers/inquirer.js
@@ -13,7 +13,7 @@ module.exports = {
   createChatvote: (msg, id, reportable = true) => {
     const existing = db.findSync('questions', {
         zd_id: parseInt(id)
-     }))
+     })
     if (existing && (Date.now() - existing.meta.created) < 30000) return // If there's a document created less than 30 seconds ago with the same ID, we don't want to create a chatvote
       
     msg.addReaction(`${ids.emojis.upvote.name}:${ids.emojis.upvote.id}`)

--- a/src/megabot-internals/controllers/inquirer.js
+++ b/src/megabot-internals/controllers/inquirer.js
@@ -15,7 +15,7 @@ module.exports = {
       zd_id: parseInt(id)
     })
     if (existing && (Date.now() - existing.meta.created) < 30000) return // If there's a document created less than 30 seconds ago with the same ID, we don't want to create a chatvote
-    
+
     msg.addReaction(`${ids.emojis.upvote.name}:${ids.emojis.upvote.id}`)
     msg.addReaction(`${ids.emojis.downvote.name}:${ids.emojis.downvote.id}`)
     if (reportable && msg.author.id === global.bot.user.id) {

--- a/src/megabot-internals/controllers/inquirer.js
+++ b/src/megabot-internals/controllers/inquirer.js
@@ -11,6 +11,11 @@ module.exports = {
    * @returns {Promise<Object>} - Database response
    */
   createChatvote: (msg, id, reportable = true) => {
+    const existing = db.findSync('questions', {
+        zd_id: parseInt(id)
+     }))
+    if (existing && (Date.now() - existing.meta.created) < 30000) return // If there's a document created less than 30 seconds ago with the same ID, we don't want to create a chatvote
+      
     msg.addReaction(`${ids.emojis.upvote.name}:${ids.emojis.upvote.id}`)
     msg.addReaction(`${ids.emojis.downvote.name}:${ids.emojis.downvote.id}`)
     if (reportable && msg.author.id === global.bot.user.id) {


### PR DESCRIPTION
# Please check the following boxes
> All boxes are required

- [x] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I tested my code and I verified it's working to the best of my ability
- [x] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

> Prevents the reactions from being added if a command like latest/translate was created less than 30 seconds ago.

**Why is this change needed?**

> Usually, when an invalid suggestion is posted, around 2/3 custodians use !l/!tr very quickly, creating multiple reportable instances. This forces the first command sent to be reported to avoid confusion.

**Does your pull request solve an open issue? If yes, please mention what one**
None.
