### PR TITLE
Latest command error message

### DIFF
--- a/src/commands/latest.js
+++ b/src/commands/latest.js
@@ -47,7 +47,7 @@ module.exports = {
           }
         }).then(z => { inquire.createChatvote(z, x.id) })
       }).catch(e => {
-        return msg.channel.createMessage(MB_CONSTANTS.generateErrorMessage(e))
+        return (e.message === 'Not Found') ? msg.channel.createMessage('This post is either being held for review or has been removed.') : msg.channel.createMessage(MB_CONSTANTS.generateErrorMessage(e))
       })
     } else return msg.channel.createMessage('You can only use this command to return info on suggestions!')
   }


### PR DESCRIPTION
> Note: I am making a new PR because in the last one I broke more things than I meant to. I figured that it would be much simpler to close that one and open a new one. Sorry!


# Please check the following boxes
> All boxes are required

- [x] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I tested my code and I verified it's working to the best of my ability
- [x] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

I am proposing changing the error message of the `!latest` command to make it more clear why the latest post can't be shown.

**Why is this change needed?**

Right now, the message says `I haven't found anything using your input. Please make sure you haven't made a typo`. The problem with this is that the latest command doesn't take any input, so you can't make a typo. When this happens, especially to new custodians, it makes it seem like they are doing something wrong, instead of telling them that the post is unavailable.

A few changes from the previous PR:

- I am no longer using the constants file
- Now, only the `Not Found` error message is changed, all other errors will show the correct message

**Does your pull request solve an open issue? If yes, please mention what one**

No.