### PR TITLE
Support, T&S and Question Comment Commands

### DIFF
--- a/src/commands/questioncomment.js
+++ b/src/commands/questioncomment.js
@@ -2,7 +2,7 @@ const ZD = require('../megabot-internals/zendesk')
 
 module.exports = {
   meta: {
-    level: 0,
+    level: 1,
     alias: ['qc', 'qcom']
   },
   fn: async (msg, suffix) => {

--- a/src/commands/questioncomment.js
+++ b/src/commands/questioncomment.js
@@ -1,0 +1,51 @@
+const ZD = require('../megabot-internals/zendesk')
+
+module.exports = {
+  meta: {
+    level: 0,
+    alias: ['qc', 'qcom']
+  },
+  fn: async (msg, suffix) => {
+    msg.channel.sendTyping()
+    const chunks = suffix.split(' ')
+    const id = chunks[0].match(MB_CONSTANTS.submissionRegex) ? chunks[0].match(MB_CONSTANTS.submissionRegex)[1] : chunks[0]
+    let suggestion
+    ZD.getSubmission(id, ['users', 'topics']).then(c => {
+      suggestion = c
+      if (c.closed) {
+        throw new Error('Suggestion closed')
+      } else {
+        return ZD.createComment({
+          discordId: msg.author.id,
+          id: id
+        }, {
+          body: 'Hi! If you have a general question about Discord, please contact Discord support here: https://dis.gd/contact or on Twitter @discordapp.'
+        })
+      }
+    }).then(() => {
+      msg.delete()
+      return msg.channel.createMessage({
+        content: 'Your comment was added',
+        embed: {
+          color: 0xfc6203,
+          author: {
+            name: suggestion.sideloads.users[0].name,
+            icon_url: suggestion.sideloads.users[0].photo ? suggestion.sideloads.users[0].photo.content_url : undefined
+          },
+          title: suggestion.title.length > 250 ? suggestion.title.substring(0, 250) + '...' : suggestion.title,
+          description: suggestion.cleanContent.length > 2048 ? '*Content too long*' : suggestion.cleanContent,
+          url: suggestion.htmlUrl,
+          footer: {
+            text: suggestion.sideloads.topics[0].name
+          },
+          fields: [
+            {
+              name: `${msg.author.username} commented on this:`,
+              value: 'Hi! If you have a general question about Discord, please contact Discord support here: https://dis.gd/contact or on Twitter @discordapp.'
+            }
+          ]
+        }
+      })
+    }).catch(e => msg.channel.createMessage(MB_CONSTANTS.generateErrorMessage(e)))
+  }
+}

--- a/src/commands/questioncomment.js
+++ b/src/commands/questioncomment.js
@@ -19,7 +19,7 @@ module.exports = {
           discordId: msg.author.id,
           id: id
         }, {
-          body: 'Hi! If you have a general question about Discord, please contact Discord support here: https://dis.gd/contact or on Twitter @discordapp.'
+          body: MB_CONSTANTS.strings.questionComment
         })
       }
     }).then(() => {
@@ -41,7 +41,7 @@ module.exports = {
           fields: [
             {
               name: `${msg.author.username} commented on this:`,
-              value: 'Hi! If you have a general question about Discord, please contact Discord support here: https://dis.gd/contact or on Twitter @discordapp.'
+              value: MB_CONSTANTS.strings.questionComment
             }
           ]
         }

--- a/src/commands/supportcomment.js
+++ b/src/commands/supportcomment.js
@@ -2,7 +2,7 @@ const ZD = require('../megabot-internals/zendesk')
 
 module.exports = {
   meta: {
-    level: 0,
+    level: 1,
     alias: ['sc', 'scom', 'bugcomment', 'bc', 'bcom']
   },
   fn: async (msg, suffix) => {

--- a/src/commands/supportcomment.js
+++ b/src/commands/supportcomment.js
@@ -1,0 +1,51 @@
+const ZD = require('../megabot-internals/zendesk')
+
+module.exports = {
+  meta: {
+    level: 0,
+    alias: ['sc', 'scom', 'bugcomment', 'bc', 'bcom']
+  },
+  fn: async (msg, suffix) => {
+    msg.channel.sendTyping()
+    const chunks = suffix.split(' ')
+    const id = chunks[0].match(MB_CONSTANTS.submissionRegex) ? chunks[0].match(MB_CONSTANTS.submissionRegex)[1] : chunks[0]
+    let suggestion
+    ZD.getSubmission(id, ['users', 'topics']).then(c => {
+      suggestion = c
+      if (c.closed) {
+        throw new Error('Suggestion closed')
+      } else {
+        return ZD.createComment({
+          discordId: msg.author.id,
+          id: id
+        }, {
+          body: 'Hello there! I\'m sorry you\'re having that problem! If you would like help troubleshooting you\'re issue, please contact Discord support here: https://dis.gd/contact.'
+        })
+      }
+    }).then(() => {
+      msg.delete()
+      return msg.channel.createMessage({
+        content: 'Your comment was added',
+        embed: {
+          color: 0xfc6203,
+          author: {
+            name: suggestion.sideloads.users[0].name,
+            icon_url: suggestion.sideloads.users[0].photo ? suggestion.sideloads.users[0].photo.content_url : undefined
+          },
+          title: suggestion.title.length > 250 ? suggestion.title.substring(0, 250) + '...' : suggestion.title,
+          description: suggestion.cleanContent.length > 2048 ? '*Content too long*' : suggestion.cleanContent,
+          url: suggestion.htmlUrl,
+          footer: {
+            text: suggestion.sideloads.topics[0].name
+          },
+          fields: [
+            {
+              name: `${msg.author.username} commented on this:`,
+              value: 'Hello there! I\'m sorry you\'re having that problem! If you would like help troubleshooting you\'re issue, please contact Discord support here: https://dis.gd/contact.'
+            }
+          ]
+        }
+      })
+    }).catch(e => msg.channel.createMessage(MB_CONSTANTS.generateErrorMessage(e)))
+  }
+}

--- a/src/commands/supportcomment.js
+++ b/src/commands/supportcomment.js
@@ -19,7 +19,7 @@ module.exports = {
           discordId: msg.author.id,
           id: id
         }, {
-          body: 'Hello there! I\'m sorry you\'re having that problem! If you would like help troubleshooting you\'re issue, please contact Discord support here: https://dis.gd/contact.'
+          body: MB_CONSTANTS.strings.supportComment
         })
       }
     }).then(() => {
@@ -41,7 +41,7 @@ module.exports = {
           fields: [
             {
               name: `${msg.author.username} commented on this:`,
-              value: 'Hello there! I\'m sorry you\'re having that problem! If you would like help troubleshooting you\'re issue, please contact Discord support here: https://dis.gd/contact.'
+              value: MB_CONSTANTS.strings.supportComment
             }
           ]
         }

--- a/src/commands/trustandsafetycomment.js
+++ b/src/commands/trustandsafetycomment.js
@@ -19,7 +19,7 @@ module.exports = {
           discordId: msg.author.id,
           id: id
         }, {
-          body: 'Hey! Thanks for wanting to report a potential Terms of Service violation, but unfortunately, this site is not the correct place to do so. Before reporting, please read this article on how to correctly report users and/or servers properly: https://dis.gd/report. You can open a ticket here: https://dis.gd/request.'
+          body: MB_CONSTANTS.strings.tsComment
         })
       }
     }).then(() => {
@@ -41,7 +41,7 @@ module.exports = {
           fields: [
             {
               name: `${msg.author.username} commented on this:`,
-              value: 'Hey! Thanks for wanting to report a potential Terms of Service violation, but unfortunately, this site is not the correct place to do so. Before reporting, please read this article on how to correctly report users and/or servers properly: https://dis.gd/report. You can open a ticket here: https://dis.gd/request.'
+              value: MB_CONSTANTS.strings.tsComment
             }
           ]
         }

--- a/src/commands/trustandsafetycomment.js
+++ b/src/commands/trustandsafetycomment.js
@@ -1,0 +1,51 @@
+const ZD = require('../megabot-internals/zendesk')
+
+module.exports = {
+  meta: {
+    level: 0,
+    alias: ['tsc', 'trustcomment', 'tscom']
+  },
+  fn: async (msg, suffix) => {
+    msg.channel.sendTyping()
+    const chunks = suffix.split(' ')
+    const id = chunks[0].match(MB_CONSTANTS.submissionRegex) ? chunks[0].match(MB_CONSTANTS.submissionRegex)[1] : chunks[0]
+    let suggestion
+    ZD.getSubmission(id, ['users', 'topics']).then(c => {
+      suggestion = c
+      if (c.closed) {
+        throw new Error('Suggestion closed')
+      } else {
+        return ZD.createComment({
+          discordId: msg.author.id,
+          id: id
+        }, {
+          body: 'Hey! Thanks for wanting to report a potential Terms of Service violation, but unfortunately, this site is not the correct place to do so. Before reporting, please read this article on how to correctly report users and/or servers properly: https://dis.gd/report. You can open a ticket here: https://dis.gd/request.'
+        })
+      }
+    }).then(() => {
+      msg.delete()
+      return msg.channel.createMessage({
+        content: 'Your comment was added',
+        embed: {
+          color: 0xfc6203,
+          author: {
+            name: suggestion.sideloads.users[0].name,
+            icon_url: suggestion.sideloads.users[0].photo ? suggestion.sideloads.users[0].photo.content_url : undefined
+          },
+          title: suggestion.title.length > 250 ? suggestion.title.substring(0, 250) + '...' : suggestion.title,
+          description: suggestion.cleanContent.length > 2048 ? '*Content too long*' : suggestion.cleanContent,
+          url: suggestion.htmlUrl,
+          footer: {
+            text: suggestion.sideloads.topics[0].name
+          },
+          fields: [
+            {
+              name: `${msg.author.username} commented on this:`,
+              value: 'Hey! Thanks for wanting to report a potential Terms of Service violation, but unfortunately, this site is not the correct place to do so. Before reporting, please read this article on how to correctly report users and/or servers properly: https://dis.gd/report. You can open a ticket here: https://dis.gd/request.'
+            }
+          ]
+        }
+      })
+    }).catch(e => msg.channel.createMessage(MB_CONSTANTS.generateErrorMessage(e)))
+  }
+}

--- a/src/commands/trustandsafetycomment.js
+++ b/src/commands/trustandsafetycomment.js
@@ -2,7 +2,7 @@ const ZD = require('../megabot-internals/zendesk')
 
 module.exports = {
   meta: {
-    level: 0,
+    level: 1,
     alias: ['tsc', 'trustcomment', 'tscom']
   },
   fn: async (msg, suffix) => {

--- a/src/megabot-internals/constants.js
+++ b/src/megabot-internals/constants.js
@@ -66,7 +66,10 @@ module.exports = {
   limiter: limiter,
   strings: {
     dupe: (x) => `Hi there! This suggestion is the same as ${process.env.ZENDESK_ROOT_URL}/hc/en-us/community/posts/${x} so in an effort to keep duplicates out and keep everything neat and tidy, we're going to merge this ticket into that suggestion. This ticket will be deleted automatically after a week.`,
-    custodianInvite: "Hey there! Just wanted to let you know we've seen you around in DFeedback, being awesome, and you've accrued enough experience to buy the coveted Custodian role! It gives you access to more channels, new commands and an absolutely awesome community! Just use this command `!buy roles 1` in this bot's DMs to buy it!"
+    custodianInvite: "Hey there! Just wanted to let you know we've seen you around in DFeedback, being awesome, and you've accrued enough experience to buy the coveted Custodian role! It gives you access to more channels, new commands and an absolutely awesome community! Just use this command `!buy roles 1` in this bot's DMs to buy it!",
+    supportComment: 'Hello there! I\'m sorry you\'re having that problem! If you would like help troubleshooting you\'re issue, please contact Discord support here: https://dis.gd/contact.',
+    tsComment: 'Hey! Thanks for wanting to report a potential Terms of Service violation, but unfortunately, this site is not the correct place to do so. Before reporting, please read this article on how to correctly report users and/or servers properly: https://dis.gd/report. You can open a ticket here: https://dis.gd/request.',
+    questionComment: 'Hi! If you have a general question about Discord, please contact Discord support here: https://dis.gd/contact or on Twitter @discordapp.'
   },
   generateErrorMessage: (e) => {
     switch (e.message) {
@@ -74,23 +77,23 @@ module.exports = {
         return `Seems this is the first time you're using the feedback system, please login first at ${process.env.ZENDESK_ROOT_URL}/hc/en-us/signin for everything to work properly.\nIf you just recently signed in for the first time, it might take a minute for me to detect it.`
       }
       case 'Not Found' : {
-        return "I haven't found anything using your input. Please make sure you haven't made a typo"
+        return "I haven't found anything using your input. Please make sure you haven't made a typo."
       }
       case 'Internal Server Error': {
-        return "Zendesk didn't respond properly for whatever reason, please try again later.\nThis issue might be related to problems over at Zendesk, please check https://status.zendesk.com"
+        return "Zendesk didn't respond properly for whatever reason; please try again later.\nThis issue might be related to problems over at Zendesk; please check https://status.zendesk.com"
       }
       case 'Suggestion closed': {
-        return "The suggestion you're trying to execute this action on, is closed"
+        return "The suggestion you're trying to execute this action on has been closed."
       }
       case 'Invalid ID' : {
-        return "Some ID's you've entered are malformed, please double check them"
+        return "Some or all of the IDs you've entered are malformed. Please double check them and try again."
       }
       case 'Timed out' : {
-        return 'You took too long to respond to this, please try again'
+        return 'You took too long to respond to this; please try again.'
       }
       default: {
         logger.error(e)
-        return "Something went wrong, and I'm not exactly sure what, try again later"
+        return "Something went wrong, and I'm not exactly sure what. Try again later."
       }
     }
   }


### PR DESCRIPTION
Now, Custodians are supposed to comment on invalid posts, refering them to T&S or Support. These commands will allow that as well as removing the ability to get xp from it, so people can't farm xp

# Please check the following boxes
> All boxes are required

- [x] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I tested my code and I verified it's working to the best of my ability
- [x] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

Custodians are now supposed to comment on invalid posts telling the user to create a support or t&s ticket. I have created 3 commands for doing this. It will make it easier and the messages will all be the same.

The commands are: 

`!trustandsafetycomment`, `!tsc`, `tscom`
`!supportcomment`, `!sc`, `!scom`
`!bugcomment`, `!bc`, `!bcom`
`!questioncomment`, `!qc`, `qcom`

The bug comment is the same as the support comment, but I feel that it would be easier for newer Custodians to have both a support and bug command.

**Why is this change needed?**

Currently, we have to copy/paste a message from a previous comment or write it ourselves. This will eliminate the need for that. I also removed the ability to get exp from this, to prevent xp farming.

**Does your pull request solve an open issue? If yes, please mention what one**

Closes: #167 

**Pics**
https://i.imgur.com/W9TePPq.png
https://i.imgur.com/dQtCGxS.png
https://i.imgur.com/E6yagjH.png