### PR TITLE
Use a different API provider for dog facts

### DIFF
--- a/src/commands/dog.js
+++ b/src/commands/dog.js
@@ -9,7 +9,7 @@ module.exports = {
   fn: async (msg) => {
     msg.channel.sendTyping()
     const start = (await SA.get('https://random.dog/woof.json?filter=mp4,webm')).body.url
-    const fact = (await SA.get('https://dog-api.kinduff.com/api/facts')).body.facts[0]
+    const fact = (await SA.get('https://some-random-api.ml/facts/dog')).body.fact
     return msg.channel.createMessage({
       embed: {
         color: 0x31c670,


### PR DESCRIPTION
# Please check the following boxes
> All boxes are required

- [X] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [X] I tested my code and I verified it's working to the best of my ability
- [X] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

This updates megabot to use a different provider (``https://some-random-api.ml/facts/dog``) for dog facts, as well as a small tweak as the api's are slightly different in how they serve the dog fact.

**Why is this change needed?**

``https://dog-api.kinduff.com/api/facts`` is down, the domain no longer exists, which makes megabot error out when using this command.

**Does your pull request solve an open issue? If yes, please mention what one**

No
